### PR TITLE
Valgrind suppression file

### DIFF
--- a/minishell.supp
+++ b/minishell.supp
@@ -1,0 +1,13 @@
+{
+   <readline_leaks>
+   Memcheck:Leak
+   ...
+   fun:readline
+}
+
+{
+   <addhistory_leaks>
+   Memcheck:Leak
+   ...
+   fun:add_history
+}


### PR DESCRIPTION
Valgrind suppression file for readline and add_history memory leaks. 

The readline and add_history built-in functions contain memory leaks (still reachable) that make the valgrind output hard to navigate (especially when fixing our own memory leaks). When used when running valgrind, ``` --suppressions=minishell.supp```, this file suppresses that output. 

Before (simple_shell.supp is a copy of minishell.supp):
![image](https://github.com/andreaulicna/42_minishell/assets/106449030/8692dca7-3ac0-4a3e-97c5-e617c31e4b0a)

After (simple_shell.supp is a copy of minishell.supp): 
![image](https://github.com/andreaulicna/42_minishell/assets/106449030/67e4b4cf-4eaf-4f11-9a5e-9e3560416115)
