### PR TITLE
Libftprintf Makefile and get_next_line() implementation changes

### DIFF
--- a/libftprintf/Makefile
+++ b/libftprintf/Makefile
@@ -6,7 +6,7 @@
 #    By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/02/04 12:42:49 by aulicna           #+#    #+#              #
-#    Updated: 2023/05/01 17:16:26 by aulicna          ###   ########.fr        #
+#    Updated: 2023/11/23 19:29:22 by aulicna          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -31,7 +31,7 @@ OBJ = $(SRC:.c=.o)
 
 LIBFT = libft
 
-CFLAGS = -Wall -Werror -Wextra
+CFLAGS = -Wall -Werror -Wextra -g
 
 GCC = gcc
 
@@ -42,13 +42,13 @@ all: $(NAME)
 bonus: all
 
 ${NAME}: $(OBJ)
-	make -C $(LIBFT) bonus
-	cp libft/libft.a ./
-	mv libft.a $(NAME)
-	$(AR) $(NAME) $(OBJ)
+	@make -C $(LIBFT) bonus
+	@cp libft/libft.a ./
+	@mv libft.a $(NAME)
+	@$(AR) $(NAME) $(OBJ)
 
 .c.o:
-	$(GCC) $(CFLAGS) -c $< -o $@
+	@$(GCC) $(CFLAGS) -c $< -o $@
 
 clean:
 	make clean -C $(LIBFT)

--- a/libftprintf/libft/Makefile
+++ b/libftprintf/libft/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: aulicna <marvin@42.fr>                     +#+  +:+       +#+         #
+#    By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/01/15 13:02:34 by aulicna           #+#    #+#              #
-#    Updated: 2023/05/01 17:05:32 by aulicna          ###   ########.fr        #
+#    Updated: 2023/11/23 19:28:54 by aulicna          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -66,7 +66,7 @@ OBJ_BONUS = $(SRC_BONUS:.c=.o)
 
 OBJ_GNL = $(SRC_GNL:.c=.o)
 
-CFLAGS = -Wall -Wextra -Werror
+CFLAGS = -Wall -Wextra -Werror -g
 
 all: $(NAME)
 
@@ -74,10 +74,10 @@ $(NAME): $(OBJ)
 	ar rc $(NAME) $(OBJ)
 
 .c.o:
-	gcc $(CFLAGS) -c $< -o $@
+	@gcc $(CFLAGS) -c $< -o $@
 
 bonus: $(OBJ) $(OBJ_BONUS) $(OBJ_GNL)
-	ar rc $(NAME) $(OBJ) $(OBJ_BONUS) $(OBJ_GNL)
+	@ar rc $(NAME) $(OBJ) $(OBJ_BONUS) $(OBJ_GNL)
 
 clean:
 	@rm -f $(OBJ) $(OBJ_BONUS) $(OBJ_GNL)

--- a/libftprintf/libft/get_next_line_bonus.c
+++ b/libftprintf/libft/get_next_line_bonus.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   get_next_line_bonus.c                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: aulicna <marvin@42.fr>                     +#+  +:+       +#+        */
+/*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/23 11:26:06 by aulicna           #+#    #+#             */
-/*   Updated: 2023/05/01 17:13:51 by aulicna          ###   ########.fr       */
+/*   Updated: 2023/11/23 19:37:20 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -102,5 +102,7 @@ char	*get_next_line(int fd)
 		return (NULL);
 	line = process_current_line(s[fd]);
 	s[fd] = save_remainder_of_line(s[fd]);
+	free(s[fd]);
+	s[fd] = NULL;
 	return (line);
 }

--- a/libftprintf/libft/get_next_line_bonus.h
+++ b/libftprintf/libft/get_next_line_bonus.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   get_next_line_bonus.h                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: aulicna <marvin@42.fr>                     +#+  +:+       +#+        */
+/*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/23 11:26:26 by aulicna           #+#    #+#             */
-/*   Updated: 2023/05/01 17:12:27 by aulicna          ###   ########.fr       */
+/*   Updated: 2023/11/23 19:35:01 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,7 @@
 # define GET_NEXT_LINE_BONUS_H
 
 # ifndef BUFFER_SIZE
-#  define BUFFER_SIZE 10
+#  define BUFFER_SIZE 1
 # endif
 
 # include <stdlib.h>


### PR DESCRIPTION
Makefile:
- Added -g flag into all the Makefiles (libftprintf and libft) to see the exact number of a line a memory leak is coming from
- Added @ in front of some commands to silence the terminal output of running them (e.g. compiling every .c file)


get_next_line()
- Changed the buffer size set in the header from 10 to 1 to read character-by-character
- Added free on the remainder of the line before return
=> the combination of the above gets rid of still reachable memory leaks