### PR TITLE
Expander (and some general) refactoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/11/23 14:30:35 by aulicna           #+#    #+#              #
-#    Updated: 2024/01/24 15:36:47 by aulicna          ###   ########.fr        #
+#    Updated: 2024/01/25 13:10:11 by aulicna          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -33,10 +33,11 @@ SRC = src/debug/main.c\
 		src/exit/free.c\
 		src/exit/free_helpers.c\
 		src/exit/free_pipe.c\
-		src/expander/quotes_delete.c\
 		src/expander/expander.c\
 		src/expander/expander_checkers.c\
 		src/expander/expander_construct.c\
+		src/expander/expander_empty_env.c\
+		src/expander/quotes_delete.c\
 		src/heredoc/heredoc.c\
 		src/heredoc/heredoc_lines.c\
 		src/lexer/ft_split_minishell.c\

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/11/23 14:30:35 by aulicna           #+#    #+#              #
-#    Updated: 2024/01/22 14:42:53 by aulicna          ###   ########.fr        #
+#    Updated: 2024/01/24 15:36:47 by aulicna          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -14,6 +14,9 @@ NAME = minishell
 
 SRC = src/debug/main.c\
 		src/debug/print.c\
+		src/setup/init.c\
+		src/setup/main_checkers.c\
+		src/setup/prompt.c\
 		src/utils/utils.c\
 		src/utils/env.c\
 		src/utils/signals.c\
@@ -30,18 +33,18 @@ SRC = src/debug/main.c\
 		src/exit/free.c\
 		src/exit/free_helpers.c\
 		src/exit/free_pipe.c\
+		src/expander/quotes_delete.c\
 		src/expander/expander.c\
-		src/expander/expander_dollar.c\
+		src/expander/expander_checkers.c\
+		src/expander/expander_construct.c\
 		src/heredoc/heredoc.c\
 		src/heredoc/heredoc_lines.c\
 		src/lexer/ft_split_minishell.c\
-		src/lexer/no_space_split.c\
 		src/lexer/lexer.c\
+		src/lexer/no_space_split.c\
+		src/lexer/quotes_split.c\
 		src/parser/parser_redirects.c\
 		src/parser/parser.c\
-		src/init.c\
-		src/prompt.c\
-		src/quotes.c\
 		src/exec/exec.c\
 		src/exec/exec_utils.c\
 		src/exec/pipe_utils.c\

--- a/incl/minishell.h
+++ b/incl/minishell.h
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/20 11:59:42 by aulicna           #+#    #+#             */
-/*   Updated: 2024/01/24 16:11:29 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/01/25 13:42:18 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -152,6 +152,10 @@ int		checker_dollar(char *str, int j);
 char	*expand_exit_status(char *str, int exit_status);
 char	*expand_dollar(char *str, t_list *env_list, int *j_cmd);
 char	*delete_backslash(char *str);
+//	expander_emtpy_env.c
+char	**ft_strdup_array(char **arr);
+void	handle_empty_envs(char **old_cmd, t_simple_cmds *content,
+		int *exit_status);
 // quotes_delete.c
 int		get_quotes_type(char *str, char *q);
 char	*delete_quotes(char *str);

--- a/incl/minishell.h
+++ b/incl/minishell.h
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/20 11:59:42 by aulicna           #+#    #+#             */
-/*   Updated: 2024/01/23 16:05:54 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/01/24 16:11:29 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -107,6 +107,17 @@ void	print_input_split(char **input_split);
 void	print_lexer(t_list **lexer);
 void	print_simple_cmds(t_list **simple_cmds);
 
+/* Setup */
+// main_checkers.c
+int		check_quotes(char *input);
+int		check_input_null(char *input);
+int		check_enter_space(char *input);
+// init.c
+void	init_data(t_data *data);
+void	init_struct_str(t_str *str);
+// prompt.c
+char	*set_prompt(t_list *env_list);
+
 /* Error */
 // error.c
 int		error_handler(int code);
@@ -132,13 +143,19 @@ void	free_pipe_child(int **fd_pipe, int i);
 /* Expander */
 // expander.c
 void	expander(t_data *data);
+void	expander_loop_dollar(t_simple_cmds *content, int i, int exit_status,
+			t_list *env_list);
+// expander_dollar_checkers.c
 int		contains_dollar(char *str);
-void	expander_loop_dollar(t_simple_cmds *content, int i, t_data *data);
-// expander_dollar.c
 int		checker_dollar(char *str, int j);
-void	expand_exit_status(char **cmd, int i_cmd, int exit_status);
-void	expand_dollar(char **cmd, int i_cmd, t_list *env_list, int *j_cmd);
-void	delete_backslash(char **cmd, int i_cmd);
+// expander_construct.c
+char	*expand_exit_status(char *str, int exit_status);
+char	*expand_dollar(char *str, t_list *env_list, int *j_cmd);
+char	*delete_backslash(char *str);
+// quotes_delete.c
+int		get_quotes_type(char *str, char *q);
+char	*delete_quotes(char *str);
+int		has_quotes_to_delete(char *str);
 
 /* Heredoc */
 // heredoc.c
@@ -149,11 +166,14 @@ void	create_heredoc(t_list *heredoc, char *hd_file_name, t_data *data);
 /* Lexer */
 // ft_split_minishell.c
 char	**ft_split_minishell(char const *s, char c);
-//	no_space_split.c
-char	**no_space_split(char **input_split, int index);
 // lexer.c
 t_tokens	is_token(char *check);
 int		input_arr_to_lexer_list(t_data *data);
+//	no_space_split.c
+char	**no_space_split(char **input_split, int index);
+// quotes.c
+void	count_qoutes(char c, unsigned int *s_quotes, unsigned int *d_quotes);
+int		quotes_pair(unsigned int s_quotes, unsigned int d_quotes);
 
 /* Parser */
 // parser.c
@@ -168,20 +188,6 @@ t_list	*env_find(t_list *head, char *variable_key);
 int		env_add(t_list **head, char *env_var);
 t_list	**env_remove(t_list **head, char *variable_key);
 size_t	strs_count(char **strs);
-
-// init.c
-void	init_data(t_data *data);
-void	init_struct_str(t_str *str);
-
-// prompt.c
-char	*set_prompt(t_list *env_list);
-
-// quotes.c
-int		has_quotes(char *str, char *q);
-int		check_quotes(char *input);
-char	*delete_quotes(char *str);
-void	count_qoutes(char c, unsigned int *s_quotes, unsigned int *d_quotes);
-int		quotes_pair(unsigned int s_quotes, unsigned int d_quotes);
 
 /* Builtins */
 void	ft_echo(char **args, t_data *data);

--- a/src/builtins/ft_echo.c
+++ b/src/builtins/ft_echo.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ft_echo.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: vbartos <vbartos@student.42prague.com>     +#+  +:+       +#+        */
+/*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/27 13:45:57 by vbartos           #+#    #+#             */
-/*   Updated: 2024/01/14 18:31:00 by vbartos          ###   ########.fr       */
+/*   Updated: 2024/01/25 13:33:01 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,7 +32,7 @@ void ft_echo(char **args, t_data *data)
 		while (args[i] != NULL)
 		{
 			ft_putstr_fd(args[i], STDOUT_FILENO);
-			if (args[i + 1] && args[i][0] != '\0')
+			if (args[i + 1])
 				ft_putstr_fd(" ", STDOUT_FILENO);
 			i++;
 		}

--- a/src/debug/main.c
+++ b/src/debug/main.c
@@ -6,29 +6,13 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/23 14:33:13 by aulicna           #+#    #+#             */
-/*   Updated: 2024/01/22 18:41:11 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/01/24 15:24:17 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../incl/minishell.h"
 
 int	g_signal = 0;
-
-int	check_input_null(char *input)
-{
-	if (input == NULL)
-		return (0);
-	else
-		add_history(input);
-	return (1);
-}
-
-int	check_enter_space(char *input)
-{
-	if (!ft_strncmp(input, " ", ft_strlen_custom(input)) || input[0] == '\0')
-		return (0);
-	return (1);
-}
 
 /**
  * @brief	Runs the minishell.

--- a/src/expander/expander.c
+++ b/src/expander/expander.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/04 14:14:28 by aulicna           #+#    #+#             */
-/*   Updated: 2024/01/24 16:10:57 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/01/25 13:43:54 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -159,8 +159,11 @@ void	expander_redirects(t_list **redirects, int exit_status,
  * ("1st level detail") while the expander_loop_dollar function traverses
  * through each character of a string ("2nd level detail").
  * 
- * Lastly, expander_redirects is called to remove quotes and expand dollar signs
+ * Then, expander_redirects is called to remove quotes and expand dollar signs
  * in redirections (word) too.
+ * 
+ * Lastly, the cmd array is checked for empty strings that are left after
+ * expanding env variables that don't exist and they're removed from the array.
  *  
  * @param	data	pointer to the t_data structure (for simple_cmds, env_list)
  */
@@ -169,12 +172,14 @@ void	expander(t_data *data)
 	t_list			*current;
 	t_simple_cmds	*content;
 	int				i;
+	char			**old_cmd;
 
 	current = data->simple_cmds;
 	while (current != NULL)
 	{
 		i = 0;
 		content = (t_simple_cmds *) current->content;
+		old_cmd = ft_strdup_array(content->cmd);
 		while (content->cmd[i])
 		{
 			if (contains_dollar(content->cmd[i]))
@@ -186,6 +191,7 @@ void	expander(t_data *data)
 		}
 		expander_redirects(&content->redirects, data->exit_status,
 			data->env_list);
+		handle_empty_envs(old_cmd, content, &data->exit_status);
 		current = current->next;
 	}
 }

--- a/src/expander/expander.c
+++ b/src/expander/expander.c
@@ -6,31 +6,11 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/04 14:14:28 by aulicna           #+#    #+#             */
-/*   Updated: 2024/01/23 22:21:59 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/01/24 16:10:57 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../incl/minishell.h"
-
-/**
- * @brief 	Checks if a string contains a dollar sign.
- * 
- * @param	str	input string to be checked
- * @return	int	returns 1 if the string contains a dollar sign; 0 otherwise
- */
-int	contains_dollar(char *str)
-{
-	int	i;
-
-	i = 0;
-	while (str[i])
-	{
-		if (str[i] == '$')
-			return (1);
-		i++;
-	}
-	return (0);
-}
 
 /**
  * @brief	Expands dollar signs in a command string based on specific
@@ -40,11 +20,13 @@ int	contains_dollar(char *str)
  * whether or not to expand a dollar sign based on the predefined conditions
  * represented by the checker_dollar function and does so where appropriate.
  * 
- * @param	content	pointer to t_simple_cmds struct
- * @param	i		index of the command string in the array to process
- * @param	data	pointer to the t_data structure (for env_list, exit_status)
+ * @param	content		pointer to t_simple_cmds struct
+ * @param	i			index of the command string in the array to process
+ * @param	exit_status	most recent exit status
+ * @param	env_list	list of environment variables
  */
-void	expander_loop_dollar(t_simple_cmds *content, int i, t_data *data)
+void	expander_loop_dollar(t_simple_cmds *content, int i, int exit_status,
+	t_list *env_list)
 {
 	int	j;
 	int	dollar_flag;
@@ -55,17 +37,17 @@ void	expander_loop_dollar(t_simple_cmds *content, int i, t_data *data)
 		if (content->cmd[i][j] == '$')
 		{
 			dollar_flag = checker_dollar(content->cmd[i], j);
-			while (ft_strchr(content->cmd[i], '"') != ft_strrchr(content->cmd[i], '"')
-				|| ft_strchr(content->cmd[i], '\'') != ft_strrchr(content->cmd[i], '\''))
+			while (has_quotes_to_delete(content->cmd[i]))
 				content->cmd[i] = delete_quotes(content->cmd[i]);
 			if (dollar_flag == 5)
 				break ;
 			else if (dollar_flag == 3)
-				delete_backslash(content->cmd, i);
+				content->cmd[i] = delete_backslash(content->cmd[i]);
 			else if (dollar_flag == 1)
-				expand_exit_status(content->cmd, i, data->exit_status);
+				content->cmd[i] = expand_exit_status(content->cmd[i],
+						exit_status);
 			else if (dollar_flag == 0)
-				expand_dollar(content->cmd, i, data->env_list, &j);
+				content->cmd[i] = expand_dollar(content->cmd[i], env_list, &j);
 		}
 		j++;
 	}
@@ -85,15 +67,83 @@ void	expander_loop_no_dollar(t_simple_cmds *content, int i)
 {
 	int	j;
 
-	while (ft_strchr(content->cmd[i], '"') != ft_strrchr(content->cmd[i], '"')
-		|| ft_strchr(content->cmd[i], '\'') != ft_strrchr(content->cmd[i], '\''))
+	while (has_quotes_to_delete(content->cmd[i]))
 		content->cmd[i] = delete_quotes(content->cmd[i]);
 	j = 0;
 	while (content->cmd[i][j])
 	{
 		if (content->cmd[i][j] == '\\')
-			delete_backslash(content->cmd, i);
+			content->cmd[i] = delete_backslash(content->cmd[i]);
 		j++;
+	}
+}
+
+/**
+ * @brief	Traverses a word (from the redirect list) and determines whether
+ * or not to expand a dollar sign based on the predefined conditions
+ * represented by the checker_dollar function and does so where appropriate.
+ * 
+ * @param	content		content of the current redirect node being processed
+ * @param	exit_status	most recent exit status
+ * @param	env_list	list of environment variables
+ */
+void	expander_redirects_loop_dollar(t_lexer *content, int exit_status,
+	t_list *env_list)
+{
+	int		i;
+	int		dollar_flag;
+
+	i = 0;
+	while (content->word[i])
+	{
+		if (content->word[i] == '$')
+		{
+			dollar_flag = checker_dollar(content->word, i);
+			while (has_quotes_to_delete(content->word))
+				content->word = delete_quotes(content->word);
+			if (dollar_flag == 1)
+				content->word = expand_exit_status(content->word,
+						exit_status);
+			else if (dollar_flag == 0)
+				content->word = expand_dollar(content->word,
+						env_list, &i);
+		}
+		i++;
+	}
+}
+
+/**
+ * @brief	Traverses the redirects list (for every node of simple_cmds),
+ * either expanding and deleting quotes, or at least deleting quotes if there
+ * are any.
+ * 
+ * The while loop traverses through the nodes of the redirects list
+ * ("1st level detail") while the expander_redirects_loop_dollar function
+ * traverses through each character of the string saved as the word
+ * ("2nd level detail").
+ * 
+ * @param	redirects	list of redirections
+ * @param	exit_status	most recent exit status
+ * @param	env_list	list of environment variables
+ */
+void	expander_redirects(t_list **redirects, int exit_status,
+	t_list *env_list)
+{
+	t_list	*current;
+	t_lexer	*content;
+
+	current = *redirects;
+	while (current)
+	{
+		content = (t_lexer *) current->content;
+		if (contains_dollar(content->word))
+			expander_redirects_loop_dollar(content, exit_status, env_list);
+		else
+		{
+			while (has_quotes_to_delete(content->word))
+				content->word = delete_quotes(content->word);
+		}
+		current = current->next;
 	}
 }
 
@@ -108,6 +158,9 @@ void	expander_loop_no_dollar(t_simple_cmds *content, int i)
  * The while loop traverses through the strings in the simple_cmds array
  * ("1st level detail") while the expander_loop_dollar function traverses
  * through each character of a string ("2nd level detail").
+ * 
+ * Lastly, expander_redirects is called to remove quotes and expand dollar signs
+ * in redirections (word) too.
  *  
  * @param	data	pointer to the t_data structure (for simple_cmds, env_list)
  */
@@ -125,11 +178,14 @@ void	expander(t_data *data)
 		while (content->cmd[i])
 		{
 			if (contains_dollar(content->cmd[i]))
-				expander_loop_dollar(content, i, data);
+				expander_loop_dollar(content, i, data->exit_status,
+					data->env_list);
 			else
 				expander_loop_no_dollar(content, i);
 			i++;
 		}
+		expander_redirects(&content->redirects, data->exit_status,
+			data->env_list);
 		current = current->next;
 	}
 }

--- a/src/expander/expander_checkers.c
+++ b/src/expander/expander_checkers.c
@@ -1,0 +1,73 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   expander_checkers.c                                :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/01/24 14:44:13 by aulicna           #+#    #+#             */
+/*   Updated: 2024/01/24 14:49:12 by aulicna          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../incl/minishell.h"
+
+/**
+ * @brief 	Checks if a string contains a dollar sign.
+ * 
+ * @param	str	input string to be checked
+ * @return	int	returns 1 if the string contains a dollar sign; 0 otherwise
+ */
+int	contains_dollar(char *str)
+{
+	int	i;
+
+	i = 0;
+	while (str[i])
+	{
+		if (str[i] == '$')
+			return (1);
+		i++;
+	}
+	return (0);
+}
+
+/**
+ * @brief	Checks the context of the dollar sign in a string.
+ * 
+ * This function analyzes the context of a dollar sign ('$') in a string 'str'
+ * at position 'j'. It examines nearby characters to determine the context
+ * of the dollar sign within the string.
+ * 
+ * @param	str	input string to check
+ * @param	j	index of the dollar sign in the string
+ * @return	int	returns a flag representing the context:
+ *              5:	$ is enclosed in single quotes
+ * 				4:	$ is followed by \ and enclosed in double quotes
+ * 				3:	$ is followed or preceded with \ (not in double quotes)
+ *              2:	$ is followed by a space, a quote (' or ")
+ * 					or there is nothing else following it
+ *              1:	$ is followed by a question mark (?)
+ *              0: 	$ appears in a context that can be expanded
+ */
+int	checker_dollar(char *str, int j)
+{
+	if ((str[0] == '\'' && str[ft_strlen_custom(str) - 1] == '\''))
+		return (5);
+	if (str[0] == '"' && str[ft_strlen_custom(str) - 1] == '"'
+		&& str[j + 1] == '\\')
+		return (4);
+	if (j - 1 >= 0)
+	{
+		if (str[j - 1] == '\\')
+			return (3);
+	}
+	if (str[j + 1] == '\\')
+		return (3);
+	if (!str[j + 1] || str[j + 1] == ' ' || str[j + 1] == '\''
+		|| str[j + 1] == '"')
+		return (2);
+	if (str[j + 1] == '?')
+		return (1);
+	return (0);
+}

--- a/src/expander/expander_empty_env.c
+++ b/src/expander/expander_empty_env.c
@@ -1,0 +1,132 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   expander_empty_env.c                               :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/01/25 13:01:16 by aulicna           #+#    #+#             */
+/*   Updated: 2024/01/25 14:02:18 by aulicna          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../incl/minishell.h"
+
+/**
+ * @brief	Duplicates a 2D array of strings.
+ * 
+ * @param	arr		original 2D array of strings
+ * @return	char**	new (duplicate of input) 2D array of strings
+ */
+char	**ft_strdup_array(char **arr)
+{
+	int		i;
+	int		len_2d;
+	char	**new_arr;
+
+	len_2d = 0;
+	while (arr[len_2d])
+		len_2d++;
+	new_arr = ft_calloc(len_2d + 1, sizeof(char *));
+	i = 0;
+	while (arr[i])
+	{
+		new_arr[i] = ft_strdup(arr[i]);
+		i++;
+	}
+	new_arr[i] = NULL;
+	return (new_arr);
+}
+
+/**
+ * @brief	Checks if all strings in a simple_cmds array are empty.
+ * 
+ * @param	cmd	simple_cmds array to check
+ * @return	int	1 if all strings in the command are empty, 0 otherwise
+ */
+int	only_empty_envs(char **cmd)
+{
+	int	i;
+
+	i = 0;
+	while (cmd[i])
+	{
+		if (cmd[i][0] != '\0')
+			return (0);
+		i++;
+	}
+	return (1);
+}
+
+/**
+ * @brief	Removes a string from simple_cmds array.
+ * 
+ * @param	cmd		original simple_cmds array
+ * @param	i		index of the string to remove
+ * @return	char**	new simple_cmds array that is a copy of the original one,
+ * 					but without the string at index i
+ */
+char	**remove_cmd_empty_env(char **cmd, int i)
+{
+	int		len_2d;
+	int		j;
+	int		new_j;
+	char	**new_cmd;
+
+	len_2d = 0;
+	while (cmd[len_2d])
+		len_2d++;
+	new_cmd = ft_calloc(len_2d, sizeof(char *));
+	j = 0;
+	new_j = 0;
+	while (cmd[j])
+	{
+		if (j == i)
+			j++;
+		new_cmd[new_j] = ft_strdup(cmd[j]);
+		j++;
+		new_j++;
+	}
+	new_cmd[new_j] = NULL;
+	free_array(cmd);
+	return (new_cmd);
+}
+
+/**
+ * @brief	Handles empty environment variables in a simple_cmds array.
+ * 
+ * It traverses through the simple_cmds array and once it encounters an empty
+ * string, it checks whether it originally contained a dollar sign. If it did, 
+ * it indicates that it used to be a non-existed env variable and should
+ * be removed from the array.
+ * 
+ * @param	old_cmd		original simple_cmds array before expander
+ * @param	content		simple_cmds node
+ * @param	exit_status	pointer to the most recet exit status
+ */
+void	handle_empty_envs(char **old_cmd, t_simple_cmds *content,
+	int *exit_status)
+{
+	int	i;
+	int	old_i;
+
+	if (only_empty_envs(content->cmd))
+	{
+		*exit_status = 0;
+		free_array(old_cmd);
+		exit_current_prompt(NULL);
+	}
+	i = 0;
+	old_i = 0;
+	while (content->cmd[i])
+	{
+		if (content->cmd[i][0] == '\0' && contains_dollar(old_cmd[old_i]))
+		{
+			content->cmd = remove_cmd_empty_env(content->cmd, i);
+			i--;
+		}
+		i++;
+		old_i++;
+	}
+	free_array(old_cmd);
+}

--- a/src/expander/quotes_delete.c
+++ b/src/expander/quotes_delete.c
@@ -1,16 +1,16 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   quotes.c                                           :+:      :+:    :+:   */
+/*   quotes_delete.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/28 12:35:35 by aulicna           #+#    #+#             */
-/*   Updated: 2024/01/23 22:11:51 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/01/24 15:37:07 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../incl/minishell.h"
+#include "../../incl/minishell.h"
 
 /**
  * @brief	Checks if a string contains quotes and determines the quote type. 
@@ -20,8 +20,7 @@
  * @param	q	pointer to a character variable that stores the quote type found
  * @return	int	returns 1 if quotes are found; 0 otherwise
  */
-
-int	has_quotes(char *str, char *q)
+int	get_quotes_type(char *str, char *q)
 {
 	int	i;
 
@@ -35,6 +34,23 @@ int	has_quotes(char *str, char *q)
 	}
 	else
 		return (0);
+}
+
+/**
+ * @brief	Checks whether there is a pair of quotes to delete from a string.
+ * 
+ * It is done by comparing the pointer to their first and last occurence. If
+ * those two equal, it means that there are no more quotes to delete as they
+ * both evaluate to NULL.
+ * 
+ * @param	str	string to check
+*/
+int	has_quotes_to_delete(char *str)
+{
+	if (ft_strchr(str, '"') != ft_strrchr(str, '"')
+		|| ft_strchr(str, '\'') != ft_strrchr(str, '\''))
+		return (1);
+	return (0);
 }
 
 /**
@@ -60,7 +76,6 @@ int	has_quotes(char *str, char *q)
  * 
  * @param 	str		string to check and potentially remove the quotes from
  */
-
 char	*delete_quotes(char *str)
 {
 	int		i;
@@ -68,7 +83,7 @@ char	*delete_quotes(char *str)
 	char	q;
 	t_str	new_str;
 
-	if (has_quotes(str, &q))
+	if (get_quotes_type(str, &q))
 	{
 		i = 0;
 		while (str[i] != q)
@@ -88,80 +103,4 @@ char	*delete_quotes(char *str)
 		return (new_str.final);
 	}
 	return (str);
-}
-
-/**
- * @brief	Counts single and double quotes in a string.
- * 
- * This function keeps track of the number of single and double quotes
- * encountered in the input string. It's used in the word-counting process
- * to correctly handle quoted substrings as part of a word.
- * 
- * @param	c			character to check
- * @param	s_quotes	pointer to the count of single quotes
- * @param	d_quotes	pointer to the count of double quotes
- */
-
-void	count_qoutes(char c, unsigned int *s_quotes, unsigned int *d_quotes)
-{
-	if (c == '\'' && !(*d_quotes % 2))
-		*s_quotes += 1;
-	else if (c == '"' && !(*s_quotes % 2))
-		*d_quotes += 1;
-}
-
-/**
- * @brief	Checks if both single and double quotes are paired.
- * 
- * This function determines whether both single and double quotes are paired in
- * a balanced manner. It's crucial for identifying if a word is enclosed in
- * a pair of matched quotes or not.
- * 
- * @param	s_quotes	count of single quotes
- * @param	d_quotes	count of double quotes
- * @return	int			1 if single and double quotes are paired, otherwise 0
- */
-
-int	quotes_pair(unsigned int s_quotes, unsigned int d_quotes)
-{
-	if (!(s_quotes % 2) && !(d_quotes % 2))
-		return (1);
-	return (0);
-}
-
-/**
- * @brief	Checks for the presence and closure of quotes in the input string.
- * 
- * It prints an error message to STDERR if unclosed quotes are found.
- * 
- * @param	input	input string to be checked for quotes
- * @return	int		returns 1 if all quotes are closed and balanced; 0 otherwise
- */
-
-int	check_quotes(char *input)
-{
-	int				i;
-	unsigned int	quotes;
-
-	quotes = 0;
-	i = 0;
-	while (input[i])
-	{
-		if (input[i] == '\'' && quotes == 0)
-			quotes = 1;
-		else if (input[i] == '\'' && quotes == 1)
-			quotes = 0;
-		else if (input[i] == '"' && quotes == 0)
-			quotes = 2;
-		else if (input[i] == '"' && quotes == 2)
-			quotes = 0;
-		i++;
-	}
-	if (quotes != 0)
-	{
-		ft_putstr_fd("Minishell cannot interpret unclosed quotes, ", 2);
-		ft_putstr_fd("please close them.\n", 2);
-		return (0);
-	}
-	return (1);
 }

--- a/src/heredoc/heredoc_lines.c
+++ b/src/heredoc/heredoc_lines.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/14 17:48:09 by aulicna           #+#    #+#             */
-/*   Updated: 2024/01/22 14:35:49 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/01/24 16:03:37 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,7 +37,7 @@ void	create_heredoc_dollar_line(int fd, char *line, t_data *data)
 	tmp_node->cmd[1] = NULL;
 	tmp_node->redirects = NULL;
 	tmp_node->hd_file = NULL;
-	expander_loop_dollar(tmp_node, 0, data);
+	expander_loop_dollar(tmp_node, 0, data->exit_status, data->env_list);
 	ft_putstr_fd(tmp_node->cmd[0], fd);
 	free_array(tmp_node->cmd);
 	free(tmp_node);

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/28 14:07:57 by aulicna           #+#    #+#             */
-/*   Updated: 2024/01/23 16:35:32 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/01/24 12:43:19 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -72,6 +72,9 @@ void	assign_word(t_lexer *content, char *word)
  * @brief	Handles redirections without spaces by detecting them and
  * reconstructing the input_split accordingly.
  *
+ * As long as there is a redirection token not separated by spaces, the function
+ * will keep calling the no_space_split that will keep reconstructing the split.
+ * 
  * @param	data	pointer to the t_data structure (for input_split)
  */
 void	handle_redirect_no_space(t_data *data)

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/28 14:07:57 by aulicna           #+#    #+#             */
-/*   Updated: 2024/01/24 12:43:19 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/01/24 15:00:49 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -87,7 +87,7 @@ void	handle_redirect_no_space(t_data *data)
 	i = 0;
 	while (input_split[i])
 	{
-		if ((has_quotes(input_split[i], &q) && (input_split[i][0] != '<'
+		if ((get_quotes_type(input_split[i], &q) && (input_split[i][0] != '<'
 				&& input_split[i][0] != '>')) || is_token(input_split[i]))
 		{
 			i++;

--- a/src/lexer/no_space_split.c
+++ b/src/lexer/no_space_split.c
@@ -6,12 +6,31 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/11 17:26:37 by aulicna           #+#    #+#             */
-/*   Updated: 2024/01/23 16:31:20 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/01/24 12:46:17 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../incl/minishell.h"
 
+/**
+ * @brief Handles a token that is in the middle of a string that needs to be
+ * reconstructed.
+ * 
+ * This function finds the first occurrence of '<', '>', or '|' in the string
+ * at index `i` in `input_split`.
+ * It then splits the string into two parts at this character:
+ * 1. the part before the character
+ * 2. and the character itself with the rest of the string
+ * 
+ * The part before the character is stored in new_input_split[new_i], and
+ * the character with the rest of the string is stored
+ * in new_input_split[new_i + 1].
+ * 
+ * @param	input_split		original input split
+ * @param	i				current index in the input_split array
+ * @param	new_input_split new input split
+ * @param	new_i			current index in the new_input_split array
+ */
 void	handle_token_in_middle(char **input_split, int i,
 	char **new_input_split, int *new_i)
 {
@@ -34,6 +53,22 @@ void	handle_token_in_middle(char **input_split, int i,
 	new_input_split[*new_i] = ft_strdup(&input_split[i][k]);
 }
 
+/**
+ * @brief	Reconstructs a string from the input_split array and stores it
+ * in the new_input_split array.
+ * 
+ * If the token is found at the beginning of the string, it is stored in 
+ * new_input_split[new_i] and the rest of the string is stored in
+ * new_input_split[new_i + 1].
+ * 
+ * Else the token is found not at the beginning of the string,
+ * handle_token_in_middle is called.
+ * 
+ * @param	input_split		original input split
+ * @param	i				current index in the input_split array
+ * @param	new_input_split new input split
+ * @param	new_i			current index in the new_input_split array
+ */
 void	reconstruct_string(char **input_split, int i,
 	char **new_input_split,	int *new_i)
 {
@@ -63,6 +98,16 @@ void	reconstruct_string(char **input_split, int i,
 		handle_token_in_middle(input_split, i, new_input_split, new_i);
 }
 
+/**
+ * @brief	Handles reconstruction of the input_split if it contains a string
+ * with a redirection token not separated by spaces.
+ * 
+ * It reconstructs (splits) only one string, identified by the index.
+ * The rest is just copied over.
+ * 
+ * @param	input_split	original input split
+ * @param	i			index of the string that will be reconstructed 
+*/
 char	**no_space_split(char **input_split, int index)
 {
 	char	**new_input_split;

--- a/src/lexer/quotes_split.c
+++ b/src/lexer/quotes_split.c
@@ -1,0 +1,52 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   quotes_split.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/01/24 15:31:17 by aulicna           #+#    #+#             */
+/*   Updated: 2024/01/24 15:33:30 by aulicna          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../incl/minishell.h"
+
+/**
+ * @brief	Counts single and double quotes in a string.
+ * 
+ * This function keeps track of the number of single and double quotes
+ * encountered in the input string. It's used in the word-counting process
+ * to correctly handle quoted substrings as part of a word.
+ * 
+ * @param	c			character to check
+ * @param	s_quotes	pointer to the count of single quotes
+ * @param	d_quotes	pointer to the count of double quotes
+ */
+
+void	count_qoutes(char c, unsigned int *s_quotes, unsigned int *d_quotes)
+{
+	if (c == '\'' && !(*d_quotes % 2))
+		*s_quotes += 1;
+	else if (c == '"' && !(*s_quotes % 2))
+		*d_quotes += 1;
+}
+
+/**
+ * @brief	Checks if both single and double quotes are paired.
+ * 
+ * This function determines whether both single and double quotes are paired in
+ * a balanced manner. It's crucial for identifying if a word is enclosed in
+ * a pair of matched quotes or not.
+ * 
+ * @param	s_quotes	count of single quotes
+ * @param	d_quotes	count of double quotes
+ * @return	int			1 if single and double quotes are paired, otherwise 0
+ */
+
+int	quotes_pair(unsigned int s_quotes, unsigned int d_quotes)
+{
+	if (!(s_quotes % 2) && !(d_quotes % 2))
+		return (1);
+	return (0);
+}

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/29 13:17:34 by aulicna           #+#    #+#             */
-/*   Updated: 2024/01/23 22:23:00 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/01/24 14:41:34 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -115,35 +115,6 @@ void	create_simple_cmds(t_list **lexer, t_list **simple_cmds)
 	ft_lstadd_back(simple_cmds, node_simple_cmds);
 }
 
-void	detect_quotes_in_redirects(t_list **simple_cmds)
-{
-	t_list			*current_simple_cmd;
-	t_simple_cmds	*content_simple_cmd;
-	t_list			*current_redirect;
-	t_lexer			*content_redirect;
-
-	current_simple_cmd = *simple_cmds;
-	while (current_simple_cmd)
-	{
-		content_simple_cmd = (t_simple_cmds *) current_simple_cmd->content;
-		if (content_simple_cmd->redirects == NULL)
-		{
-			current_simple_cmd = current_simple_cmd->next;
-			continue ;
-		}
-		current_redirect = content_simple_cmd->redirects;
-		while (current_redirect)
-		{
-			content_redirect = (t_lexer *) current_redirect->content;
-			while (ft_strchr(content_redirect->word, '"') != ft_strrchr(content_redirect->word, '"')
-				|| ft_strchr(content_redirect->word, '\'') != ft_strrchr(content_redirect->word, '\''))
-				content_redirect->word = delete_quotes(content_redirect->word);
-			current_redirect = current_redirect->next;
-		}
-		current_simple_cmd = current_simple_cmd->next;
-	}
-}
-
 /**
  * @brief	Converts lexer list to a list of simple commands.
  * 
@@ -186,6 +157,5 @@ int	lexer_to_simple_cmds(t_list **lexer, t_list **simple_cmds)
 		create_simple_cmds(lexer, simple_cmds);
 		current = *lexer;
 	}
-	detect_quotes_in_redirects(simple_cmds);
 	return (EXIT_SUCCESS);
 }

--- a/src/setup/init.c
+++ b/src/setup/init.c
@@ -6,11 +6,11 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/08 12:06:21 by aulicna           #+#    #+#             */
-/*   Updated: 2024/01/17 14:03:40 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/01/24 15:22:03 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../incl/minishell.h"
+#include "../../incl/minishell.h"
 
 // init_data
 // - initializes all elements of the data struct to NULL;

--- a/src/setup/main_checkers.c
+++ b/src/setup/main_checkers.c
@@ -1,0 +1,65 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   main_checkers.c                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/01/24 15:23:41 by aulicna           #+#    #+#             */
+/*   Updated: 2024/01/24 15:26:32 by aulicna          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../incl/minishell.h"
+
+/**
+ * @brief	Checks for the presence and closure of quotes in the input string.
+ * 
+ * It prints an error message to STDERR if unclosed quotes are found.
+ * 
+ * @param	input	input string to be checked for quotes
+ * @return	int		returns 1 if all quotes are closed and balanced; 0 otherwise
+ */
+int	check_quotes(char *input)
+{
+	int				i;
+	unsigned int	quotes;
+
+	quotes = 0;
+	i = 0;
+	while (input[i])
+	{
+		if (input[i] == '\'' && quotes == 0)
+			quotes = 1;
+		else if (input[i] == '\'' && quotes == 1)
+			quotes = 0;
+		else if (input[i] == '"' && quotes == 0)
+			quotes = 2;
+		else if (input[i] == '"' && quotes == 2)
+			quotes = 0;
+		i++;
+	}
+	if (quotes != 0)
+	{
+		ft_putstr_fd("Minishell cannot interpret unclosed quotes, ", 2);
+		ft_putstr_fd("please close them.\n", 2);
+		return (0);
+	}
+	return (1);
+}
+
+int	check_input_null(char *input)
+{
+	if (input == NULL)
+		return (0);
+	else
+		add_history(input);
+	return (1);
+}
+
+int	check_enter_space(char *input)
+{
+	if (!ft_strncmp(input, " ", ft_strlen_custom(input)) || input[0] == '\0')
+		return (0);
+	return (1);
+}

--- a/src/setup/prompt.c
+++ b/src/setup/prompt.c
@@ -6,11 +6,11 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/24 12:09:39 by aulicna           #+#    #+#             */
-/*   Updated: 2024/01/17 19:47:40 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/01/24 15:22:07 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "../incl/minishell.h"
+#include "../../incl/minishell.h"
 
 /**
  * @brief	Retrieves the hostname of the system from 


### PR DESCRIPTION
- #126 
  - Refactored the code in ```expander_construct.c``` so that the functions return the newly constructed string (with $ expanded) and can be reused
  - Add a function (+ helper function) looping through the redirects list for each node of ```simple_cmds``` list, expanding the value saved in ```word``` where appropriate

- #125 
  - Documented functions ```in no_space_split``` that detects redirection tokens that are not separated by spaces

- #129 
  - Empty strings in the ```simple_cmds array``` that used to be non-existent environment variables are now handled in the expander
    - If the ```simple_cmds``` array contained only one element that was a non-existent env variable, the current prompt is exited with the ```exit_status``` set to 0
    - If there were more elements in the ```simple_cmds``` array a copy of the original ```simple_cmds``` array (before expansion) is used to determine whether or not an empty string should be removed from the array (those that used to be non-existent environment variables are removed)
  - Small change in ```ft_echo``` to make the above work:
    -  Removed a check for ```\0``` before printing a space, since for ```echo ''```,  ``args[i + 1]`` doesn't exist, and hence the printing of the space will be skipped already
     
- **Other**
  - Moved functions and files (only mine really) around to have a clearer (at least for me :sweat_smile:) structure of where things are 
    - ```setup``` directory is meant to include everything we need to set the minishell for running, right now it includes: ```main_checkers.c``` (moved from main.c), ```init.c``` and ```prompt.c``` (weren't in a dedicated directory)
    - a file previously called ```quotes.c``` (and not in a dedicated directory) was split into ```quotes_split.c``` in ```lexer``` directory and ```quotes_expander.c``` in ```expander``` directory