### PR TITLE
Small heredoc and parser fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/11/23 14:30:35 by aulicna           #+#    #+#              #
-#    Updated: 2024/01/27 18:50:48 by aulicna          ###   ########.fr        #
+#    Updated: 2024/01/27 21:34:38 by aulicna          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -44,8 +44,9 @@ SRC = src/debug/main.c\
 		src/lexer/lexer.c\
 		src/lexer/no_space_split.c\
 		src/lexer/quotes_split.c\
-		src/parser/parser_redirects.c\
 		src/parser/parser.c\
+		src/parser/parser_redirects.c\
+		src/parser/open_pipe.c\
 		src/exec/exec.c\
 		src/exec/exec_utils.c\
 		src/exec/pipe_utils.c\

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/11/23 14:30:35 by aulicna           #+#    #+#              #
-#    Updated: 2024/01/25 13:10:11 by aulicna          ###   ########.fr        #
+#    Updated: 2024/01/27 18:50:48 by aulicna          ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -63,7 +63,7 @@ CC = cc
 LIBFTPRINTF = libftprintf
 
 all: libs $(NAME)
-	@rm -f src/heredoc/.tmp*
+	@find ~/ -name ".tmp_heredoc_*" -type f -delete
 	@echo "minishell executable ready ✅"
 
 %.o: %.c
@@ -79,7 +79,7 @@ $(NAME): $(OBJ)
 
 clean:
 	@rm -f $(OBJ)
-	@rm -f src/heredoc/.tmp*
+	@find ~/ -name ".tmp_heredoc_*" -type f -delete
 	@make clean -C $(LIBFTPRINTF)
 
 fclean: clean

--- a/incl/minishell.h
+++ b/incl/minishell.h
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/20 11:59:42 by aulicna           #+#    #+#             */
-/*   Updated: 2024/01/25 13:42:18 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/01/27 21:38:46 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -155,7 +155,7 @@ char	*delete_backslash(char *str);
 //	expander_emtpy_env.c
 char	**ft_strdup_array(char **arr);
 void	handle_empty_envs(char **old_cmd, t_simple_cmds *content,
-		int *exit_status);
+			int *exit_status);
 // quotes_delete.c
 int		get_quotes_type(char *str, char *q);
 char	*delete_quotes(char *str);
@@ -185,6 +185,8 @@ int		lexer_to_simple_cmds(t_list **lexer, t_list **simple_cmds);
 // parser_redirects.c
 void	separate_redirects(t_list **lexer, t_list **redirects);
 void	free_lexer_node(t_list **lexer, int id);
+// open_pipe.c
+void	handle_open_pipe(t_data *data);
 
 // env.c
 int		env_init(char **envp, t_data *data);

--- a/src/debug/main.c
+++ b/src/debug/main.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/23 14:33:13 by aulicna           #+#    #+#             */
-/*   Updated: 2024/01/27 21:34:01 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/01/29 10:58:01 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,7 +41,7 @@ int	minishell_loop(t_data *data)
 	if (!check_input_null(data->input))
 	{
 		ft_putendl_fd("exit", STDOUT);
-		exit_minishell(NULL, 50);
+		exit_minishell(NULL, 0);
 	}
 	if (!check_quotes(data->input) || !check_enter_space(data->input))
 		exit_current_prompt(data);

--- a/src/debug/main.c
+++ b/src/debug/main.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/23 14:33:13 by aulicna           #+#    #+#             */
-/*   Updated: 2024/01/24 15:24:17 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/01/27 21:34:01 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,6 +50,7 @@ int	minishell_loop(t_data *data)
 	lexer_to_simple_cmds(&data->lexer, &data->simple_cmds);
 	expander(data);
 	heredoc(data);
+	handle_open_pipe(data);
 	if (g_signal == 0)
 		exec(data, data->simple_cmds);
 	exit_current_prompt(data);
@@ -101,6 +102,7 @@ int	minishell_loop(t_data *data)
 //	heredoc(data);
 //	printf("----------------------\n");
 //	printf("SIMPLE CMDS - after heredoc\n");
+//	handle_open_pipe(data);
 //	if (g_signal == 0)
 //		exec(data, data->simple_cmds);
 //	exit_current_prompt(data);

--- a/src/heredoc/heredoc.c
+++ b/src/heredoc/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/14 10:23:00 by aulicna           #+#    #+#             */
-/*   Updated: 2024/01/22 14:36:33 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/01/27 18:41:33 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,7 @@ char	*get_hd_file_name(void)
 
 	i++;
 	str_i = ft_itoa(i);
-	hd_file_name = ft_strjoin("./src/heredoc/.tmp_heredoc_", str_i);
+	hd_file_name = ft_strjoin(".tmp_heredoc_", str_i);
 	free(str_i);
 	return (hd_file_name);
 }

--- a/src/parser/open_pipe.c
+++ b/src/parser/open_pipe.c
@@ -1,0 +1,93 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   open_pipe.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/01/27 21:33:29 by aulicna           #+#    #+#             */
+/*   Updated: 2024/01/27 21:39:05 by aulicna          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../incl/minishell.h"
+
+/**
+ * @brief	Initializes a temporary data structure.
+ * 
+ * The tmp_data struct uses the env_list from the original data struct, process
+ * additional input via input and input_split variables and has lexer and
+ * simple_cmds set to NULL as that is what parsing functions expect.
+ * 
+ * Ctrl + D and newline (enter) input cases are handled as in bash. Ctrl + C
+ * case is not handled as it was deemed out of scope (the handle_open_pipe
+ * which is the caller of this function is a nice-to-have).
+ * 
+ * @param	tmp_data	pointer to a temporary t_data structure 
+ * @param	env_list	list of env variables from the original data struct
+ */
+static void	init_tmp_data(t_data *tmp_data, t_list *env_list)
+{
+	tmp_data->env_list = env_list;
+	tmp_data->lexer = NULL;
+	tmp_data->simple_cmds = NULL;
+	while (42)
+	{
+		tmp_data->input = readline("> ");
+		if (tmp_data->input == NULL)
+		{
+			ft_putendl_fd("minishell: syntax error: unexpected end of "
+				"file", STDERR);
+			ft_putendl_fd("exit", STDOUT);
+			exit_minishell(NULL, 2);
+		}
+		if (tmp_data->input[0] != '\0')
+			break ;
+	}
+	tmp_data->input_split = ft_split_minishell(tmp_data->input, ' ');
+}
+
+/**
+ * @brief	Handles the case where the last character in the input is a pipe.
+ * 
+ * This function checks if the last character in the input is a pipe. If it is,
+ * it handles the waiting and parsing of additional input provided
+ * by the user. It initializes a temporary data structure, converts the input
+ * into a lexer list and simple commands, expands the commands, handles heredoc
+ * and then adds the additional input (now in the form of simple_cmds nodes)
+ * at the end of the simple_cmds list in the original data structure.
+ * Then it frees the temporary input, input_split and lexer. The free_data
+ * function is not used here as the tmp_data struct wasn't used in its full
+ * scope and some data is still needed by the original data struct (env_list and 
+ * the newly added simple_cmds nodes as ft_lstadd_back just assigns pointers, 
+ * not copies).
+ * 
+ * @param	data	pointer to the t_data structure 
+ */
+void	handle_open_pipe(t_data *data)
+{
+	t_data	tmp_data;
+	t_list	*current;
+	int		len_2d;
+
+	len_2d = 0;
+	while (data->input_split[len_2d])
+		len_2d++;
+	if (!ft_strncmp(data->input_split[len_2d - 1], "|", 2))
+	{
+		init_tmp_data(&tmp_data, data->env_list);
+		input_arr_to_lexer_list(&tmp_data);
+		lexer_to_simple_cmds(&tmp_data.lexer, &tmp_data.simple_cmds);
+		expander(&tmp_data);
+		heredoc(&tmp_data);
+		current = tmp_data.simple_cmds;
+		while (current)
+		{
+			ft_lstadd_back(&data->simple_cmds, current);
+			current = current->next;
+		}
+		free(tmp_data.input);
+		free_array(tmp_data.input_split);
+		free_lexer(&tmp_data.lexer);
+	}
+}

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/29 13:17:34 by aulicna           #+#    #+#             */
-/*   Updated: 2024/01/27 19:05:49 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/01/27 20:26:00 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -154,7 +154,7 @@ int	lexer_to_simple_cmds(t_list **lexer, t_list **simple_cmds)
 		if (current)
 			content = (t_lexer *) current->content;
 		else
-			error_parser_double_token(content->token);
+			break ;
 		if (content->token == PIPE)
 			error_parser_double_token(1);
 		create_simple_cmds(lexer, simple_cmds);

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/29 13:17:34 by aulicna           #+#    #+#             */
-/*   Updated: 2024/01/24 14:41:34 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/01/27 19:05:49 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -151,7 +151,10 @@ int	lexer_to_simple_cmds(t_list **lexer, t_list **simple_cmds)
 			free_lexer_node(lexer, content->id);
 			current = *lexer;
 		}
-		content = (t_lexer *) current->content;
+		if (current)
+			content = (t_lexer *) current->content;
+		else
+			error_parser_double_token(content->token);
 		if (content->token == PIPE)
 			error_parser_double_token(1);
 		create_simple_cmds(lexer, simple_cmds);

--- a/src/setup/main_checkers.c
+++ b/src/setup/main_checkers.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/24 15:23:41 by aulicna           #+#    #+#             */
-/*   Updated: 2024/01/24 15:26:32 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/01/29 10:42:30 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,7 +59,15 @@ int	check_input_null(char *input)
 
 int	check_enter_space(char *input)
 {
-	if (!ft_strncmp(input, " ", ft_strlen_custom(input)) || input[0] == '\0')
-		return (0);
-	return (1);
+	int	i;
+
+	i = 0;
+	while (input[i])
+	{
+		if (!(7 <= input[i] && input[i] <= 13)
+			&& input[i] != 32 && input[i] != '\0')
+			return (1);
+		i++;
+	}
+	return (0);
 }


### PR DESCRIPTION
- Heredoc now works in every directory (= heredoc.c change) and its tmp files get deleted from the home directory and all its subdirectories (= Makefile change)
- Added handling for open pipe:
  - minishell now waits for the first line of user input (that is not NULL or a newline/enter), parses it as the main input is parsed and then adds the resulting simple_cmds node(s) at the end of the existing simple_cmds list in the main data struct
  - special input cases:
    - Ctrl + D: behaves as in bash -> prints an error message and exits minishell
    - NULL:  behaves as in bash -> prints another readline line
    - newline/ enter: behaves as in bash -> prints another readline line
    - Ctrl + C: doesn't behave as in bash -> left out and hence ends up printing another readline line
```
ls |
> src/

echo hi |
> wc -l
```

- #141 
  - Changed ```check_enter_space``` to check for all whitespaces, so that such input is discarded and a new prompt displayed before any actually parsing stars