### PR TITLE
Signals management and expander fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,6 @@
 This project is about recreating our own version of bash with limited functionality.
 A miniature shell :).
 
-## Valgrind
-```valgrind -s --leak-check=full --show-reachable=yes --error-limit=no --suppressions=minishell.supp --trace-children=yes --track-fds=yes ./minishell```
-
-- ```-s```: same as --show-error-list=yes that shows detected errors list and suppression count at exit
-- ```--leak-check=full```: shows a full list of memory leaks
-- ```--show-reachable=yes```: same as ```--show-leak-kinds=all``` that shows all kinds of memory leaks
-- ```--error-limit=no```: won't stop showing errors if too many
-- ```--suppressions=minishell.supp```: suppresses memory leaks from in-built functions (readline and add_history)
-- ```--trace-children=yes```: checks memory leaks in child process too
-- ```--track-fds=yes```: tracks open and closed file descriptors
-
 ### Permitted functions and their description
 | Function        | Description                                                                 |
 |-----------------|-----------------------------------------------------------------------------|
@@ -69,3 +58,27 @@ A miniature shell :).
 | tgetstr         | Retrieves a string capability from the terminal description.                |
 | tgoto           | Decodes a cursor motion string.                                             |
 | tputs           | Puts a terminal string with padding.   
+
+### Test cases
+#### Simple commands with absolute path
+```
+/bin/ls src
+/bin/pwd hello
+/bin/date
+/usr/bin/head -n 10 Makefile
+/bin/grep # Makefile
+/usr/bin/uname -a
+/usr/bin/head Makefile
+/usr/bin/tail Makefile
+```
+
+### Valgrind
+```valgrind -s --leak-check=full --show-reachable=yes --error-limit=no --suppressions=minishell.supp --trace-children=yes --track-fds=yes ./minishell```
+
+- ```-s```: same as --show-error-list=yes that shows detected errors list and suppression count at exit
+- ```--leak-check=full```: shows a full list of memory leaks
+- ```--show-reachable=yes```: same as ```--show-leak-kinds=all``` that shows all kinds of memory leaks
+- ```--error-limit=no```: won't stop showing errors if too many
+- ```--suppressions=minishell.supp```: suppresses memory leaks from in-built functions (readline and add_history)
+- ```--trace-children=yes```: checks memory leaks in child process too
+- ```--track-fds=yes```: tracks open and closed file descriptors

--- a/incl/minishell.h
+++ b/incl/minishell.h
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/20 11:59:42 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/02 16:13:38 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/05 00:22:49 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -141,9 +141,12 @@ void	free_pipe_child(int **fd_pipe, int i);
 void	expander(t_data *data);
 void	expander_loop_dollar(t_simple_cmds *content, int i, int exit_status,
 			t_list *env_list);
+void	expander_loop_dollar_no_space(t_data *data, t_simple_cmds *content,
+			int i);
 // expander_dollar_checkers.c
 int		contains_dollar(char *str);
 int		checker_dollar(char *str, int j);
+int		env_in_quotes_followed(char *str);
 // expander_construct.c
 char	*expand_exit_status(char *str, int exit_status);
 char	*expand_dollar(char *str, t_list *env_list, int *j_cmd);

--- a/incl/minishell.h
+++ b/incl/minishell.h
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/20 11:59:42 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/05 14:32:38 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/05 17:31:43 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -228,7 +228,9 @@ void	fork_process(int *pid);
 
 /* Signals */
 void	handle_sigint(int sig_num);
+void	handle_sigint_with_child(int sig_num);
 void	handle_sigint_heredoc(int sig_num);
-void	handle_sigint_hanging_command(int sig_num);
+void	reset_signals_default(void);
+int		signal_exit_of_child(int *status);
 
 #endif

--- a/incl/minishell.h
+++ b/incl/minishell.h
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/20 11:59:42 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/05 17:31:43 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/05 22:50:46 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -228,7 +228,7 @@ void	fork_process(int *pid);
 
 /* Signals */
 void	handle_sigint(int sig_num);
-void	handle_sigint_with_child(int sig_num);
+void	handle_sigint_when_child_running(int sig_num);
 void	handle_sigint_heredoc(int sig_num);
 void	reset_signals_default(void);
 int		signal_exit_of_child(int *status);

--- a/incl/minishell.h
+++ b/incl/minishell.h
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/20 11:59:42 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/05 00:22:49 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/05 14:32:38 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -158,7 +158,8 @@ void	handle_empty_envs(char **old_cmd, t_simple_cmds *content,
 // quotes_delete.c
 int		get_quotes_type(char *str, char *q);
 char	*delete_quotes(char *str);
-int		has_quotes_to_delete(char *str);
+int		has_quotes_to_delete(char *str, char *old_cmd);
+void	handle_quotes_deletion(t_simple_cmds *content, int i);
 
 /* Heredoc */
 // heredoc.c

--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/23 14:33:13 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/05 17:27:54 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/05 23:19:00 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,20 +17,10 @@ int	g_signal = 0;
 /**
  * @brief	Runs the minishell.
  * 
- * Signal lines:
- * 1. SIGINT: Sets up the signal handler for SIGINT (Ctrl + C), so that 
- * minishell displays a new prompt when the signal is received.
- * 2. SIGQUIT: Ignores SIGQUIT (Ctrl + \), so that minishell doesn't quit when
- * the signal is received.
- * 3. global_signal: Is set to 0 to indicate that the heredoc process has not
- * been run (and may not even be) yet for the current command, and so
- * the execution will be run unless the heredoc process is interrupted with
- * SIGINT (Ctrl + C) when (and if) it runs.
- * 
- * The global variable g_signal is checked before the execution is launched
- * because in case it isn't 0 (but SIGUSR1), it indicates that the heredoc
- * process was interrupted with SIGINT (Ctrl + C), and so the whole command
- * should be canceled and a new prompt displayed.
+ * Signals management:
+ * SIGINT signal is handled via the primary SIGINT handler which displays a new
+ * prompt and sets g_signal to SIGINT so that this value cam inform the exit
+ * status used in the expander.
 */
 int	minishell_loop(t_data *data)
 {

--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/23 14:33:13 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/02 14:27:39 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/05 17:27:54 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,7 +51,7 @@ int	minishell_loop(t_data *data)
 	expander(data);
 	heredoc(data);
 	handle_open_pipe(data);
-	if (g_signal != SIGUSR1)
+	if (g_signal == 0)
 		exec(data, data->simple_cmds);
 	exit_current_prompt(data);
 	return (1);

--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/23 14:33:13 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/05 23:19:00 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/06 13:38:01 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,7 +41,7 @@ int	minishell_loop(t_data *data)
 	expander(data);
 	heredoc(data);
 	handle_open_pipe(data);
-	if (g_signal == 0)
+	if (g_signal != SIGINT)
 		exec(data, data->simple_cmds);
 	exit_current_prompt(data);
 	return (1);

--- a/src/debug/print.c
+++ b/src/debug/print.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/12 10:28:47 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/01 15:56:37 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/04 18:08:40 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -127,8 +127,8 @@ void	print_simple_cmds(t_list **simple_cmds)
 //	printf("SIMPLE CMDS - before expander\n");
 //	print_simple_cmds(&data->simple_cmds);
 //	printf("----------------------\n");
-//	printf("SIMPLE CMDS - after expander\n");
 //	expander(data);
+//	printf("SIMPLE CMDS - after expander\n");
 //	print_simple_cmds(&data->simple_cmds);
 //	printf("----------------------\n");
 //	printf("Heredoc output:\n");
@@ -136,7 +136,7 @@ void	print_simple_cmds(t_list **simple_cmds)
 //	printf("----------------------\n");
 //	printf("SIMPLE CMDS - after heredoc\n");
 //	handle_open_pipe(data);
-//	if (g_signal != SIGUSR1)
+//	if (g_signal == 0)
 //		exec(data, data->simple_cmds);
 //	exit_current_prompt(data);
 //	return (1); //should never reach this

--- a/src/debug/print.c
+++ b/src/debug/print.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/12 10:28:47 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/04 18:08:40 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/06 13:47:23 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -136,7 +136,7 @@ void	print_simple_cmds(t_list **simple_cmds)
 //	printf("----------------------\n");
 //	printf("SIMPLE CMDS - after heredoc\n");
 //	handle_open_pipe(data);
-//	if (g_signal == 0)
+//	if (g_signal != SIGINT)
 //		exec(data, data->simple_cmds);
 //	exit_current_prompt(data);
 //	return (1); //should never reach this

--- a/src/exec/exec.c
+++ b/src/exec/exec.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/14 11:33:30 by vbartos           #+#    #+#             */
-/*   Updated: 2024/02/04 18:32:23 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/05 16:54:34 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -97,10 +97,7 @@ void	exec_pipeline(t_data *data, t_list *simple_cmds, int cmds_num)
 		fd_pipe[i] = malloc(sizeof(int) * 2);
 		pipe_create(fd_pipe, i);
 		data->pid_list[i] = fork_cmd(data, simple_cmds, fd_pipe, i);
-	//	signal(SIGINT, handle_sigint_hanging_command);
-	//	signal(SIGUSR2, SIG_IGN);
-		signal(SIGINT, SIG_IGN);
-		signal(SIGUSR1, SIG_IGN);
+		signal(SIGINT, handle_sigint_with_child);
 		close(fd_pipe[i][PIPE_WRITE]);
 		if (i > 0)
 			close(fd_pipe[i - 1][PIPE_READ]);
@@ -148,8 +145,7 @@ int	fork_cmd(t_data *data, t_list *simple_cmds, int **fd_pipe, int i)
 	fork_process(&pid);
 	if (pid == 0)
 	{
-	//	signal(SIGUSR2, handle_sigint_hanging_command);
-	//	signal(SIGINT, SIG_IGN);
+		reset_signals_default();
 		pipe_redirect(simple_cmds, fd_pipe, i);
 		free_pipe_child(fd_pipe, i);
 		if (content->redirects)

--- a/src/exec/exec.c
+++ b/src/exec/exec.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/14 11:33:30 by vbartos           #+#    #+#             */
-/*   Updated: 2024/02/04 15:36:01 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/04 18:32:23 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -97,8 +97,10 @@ void	exec_pipeline(t_data *data, t_list *simple_cmds, int cmds_num)
 		fd_pipe[i] = malloc(sizeof(int) * 2);
 		pipe_create(fd_pipe, i);
 		data->pid_list[i] = fork_cmd(data, simple_cmds, fd_pipe, i);
-		signal(SIGINT, handle_sigint_hanging_command);
-		signal(SIGUSR2, SIG_IGN);
+	//	signal(SIGINT, handle_sigint_hanging_command);
+	//	signal(SIGUSR2, SIG_IGN);
+		signal(SIGINT, SIG_IGN);
+		signal(SIGUSR1, SIG_IGN);
 		close(fd_pipe[i][PIPE_WRITE]);
 		if (i > 0)
 			close(fd_pipe[i - 1][PIPE_READ]);
@@ -146,8 +148,8 @@ int	fork_cmd(t_data *data, t_list *simple_cmds, int **fd_pipe, int i)
 	fork_process(&pid);
 	if (pid == 0)
 	{
-		signal(SIGUSR2, handle_sigint_hanging_command);
-		signal(SIGINT, SIG_IGN);
+	//	signal(SIGUSR2, handle_sigint_hanging_command);
+	//	signal(SIGINT, SIG_IGN);
 		pipe_redirect(simple_cmds, fd_pipe, i);
 		free_pipe_child(fd_pipe, i);
 		if (content->redirects)

--- a/src/exec/pipe_utils.c
+++ b/src/exec/pipe_utils.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/07 22:14:18 by vbartos           #+#    #+#             */
-/*   Updated: 2024/02/02 14:57:09 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/05 17:35:31 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -108,13 +108,13 @@ int	wait_for_pipeline(int cmds_num, int **fd_pipe, int i, int pid_list[])
 		waitpid(pid_list[j], &status, 0);
 		if (WIFEXITED(status))
 			exit_status = WEXITSTATUS(status);
+		else if (WIFSIGNALED(status))
+			exit_status = signal_exit_of_child(&status);
 		j++;
 	}
 	if (cmds_num > 0)
 		close(fd_pipe[i - 1][PIPE_READ]);
 	if (cmds_num != 1)
 		close(fd_pipe[i - 2][PIPE_WRITE]);
-	if (g_signal == SIGUSR2)
-		exit_status = 130;
 	return (exit_status);
 }

--- a/src/exec/pipe_utils.c
+++ b/src/exec/pipe_utils.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/07 22:14:18 by vbartos           #+#    #+#             */
-/*   Updated: 2024/02/05 17:35:31 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/06 00:35:59 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -84,13 +84,16 @@ void	pipe_redirect(t_list *simple_cmds, int **fd_pipe, int i)
 /**
  * @brief	Waits for all processes in the pipeline to finish.
  * 
+ * Signals management:
+ * They way a child process exits is checked and if it exited due
+ * to a signal - WIFSIGNALED (rather than via exit_minishell - WIFEXITED)
+ * the signal_exit_of_child makes the parent process take the correct (printing)
+ * action, resets g_signal if needed and returns the correct exit status.
+ * 
+ * Details:
  * The if and else statement after while loop ensure there is no fd left open
  * in the parent process for one command and piped commands, respectively.
  * 
- * The last if handles the case of a hanging command (e.g. cat or sort) getting
- * interrupted by SIGINT as g_signal == SIGUSR2 indicates that there was
- * such a command and therefore the exit_status should be set to 130.
- *
  * @param	data		pointer to the t_data structure (for exit_status)
  * @param	cmds_num	number of commands in the pipeline
  * @param	fd_pipe		2d array of file descriptors

--- a/src/exit/free_pipe.c
+++ b/src/exit/free_pipe.c
@@ -6,12 +6,18 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/22 13:17:14 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/04 15:53:43 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/05 00:57:05 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../incl/minishell.h"
 
+/**
+ * @brief	Frees all the malloced pipes after executing the whole pipeline.
+ * 
+ * @param	fd_pipe		array of pipes to free
+ * @param	num_cmds	number of commands (lstsize simple_cmds) in the pipeline
+*/
 void	free_pipe(int **fd_pipe, int num_cmds)
 {
 	int	i;
@@ -25,9 +31,21 @@ void	free_pipe(int **fd_pipe, int num_cmds)
 	free(fd_pipe);
 }
 
+/**
+ * @brief	Frees malloced pipes in the child process. That includes all
+ * the pipes up until and including the current one.
+ * 
+ * The read end of the second to last pipe (from the child process's point
+ * of view) is closed as not to leave an open file descriptor upon child
+ * process exit (e.g. when the content of the pipe was ignored by the command).
+ * 
+ * @param	fd_pipe		array of pipes to free
+ * @param	i			index of the current pipe
+*/
 void	free_pipe_child(int **fd_pipe, int i)
 {
 	int	j;
+
 	if (i > 0)
 	{
 		close(fd_pipe[i - 1][PIPE_READ]);

--- a/src/expander/expander.c
+++ b/src/expander/expander.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/04 14:14:28 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/05 01:33:36 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/05 14:33:27 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,8 +28,8 @@
 void	expander_loop_dollar(t_simple_cmds *content, int i, int exit_status,
 	t_list *env_list)
 {
-	int	j;
-	int	dollar_flag;
+	int		j;
+	int		dollar_flag;
 
 	j = 0;
 	while (content->cmd[i][j])
@@ -37,11 +37,13 @@ void	expander_loop_dollar(t_simple_cmds *content, int i, int exit_status,
 		if (content->cmd[i][j] == '$')
 		{
 			dollar_flag = checker_dollar(content->cmd[i], j);
-			while (has_quotes_to_delete(content->cmd[i]))
-				content->cmd[i] = delete_quotes(content->cmd[i]);
 			if (dollar_flag == 5)
+			{
+				content->cmd[i] = delete_quotes(content->cmd[i]);
 				break ;
-			else if (dollar_flag == 3)
+			}
+			handle_quotes_deletion(content, i);
+			if (dollar_flag == 3)
 				content->cmd[i] = delete_backslash(content->cmd[i]);
 			else if (dollar_flag == 1)
 				content->cmd[i] = expand_exit_status(content->cmd[i],
@@ -67,7 +69,7 @@ static void	expander_loop_no_dollar(t_simple_cmds *content, int i)
 {
 	int	j;
 
-	while (has_quotes_to_delete(content->cmd[i]))
+	while (has_quotes_to_delete(content->cmd[i], NULL))
 		content->cmd[i] = delete_quotes(content->cmd[i]);
 	j = 0;
 	while (content->cmd[i][j])
@@ -99,7 +101,7 @@ static void	expander_redirects_loop_dollar(t_lexer *content, int exit_status,
 		if (content->word[i] == '$')
 		{
 			dollar_flag = checker_dollar(content->word, i);
-			while (has_quotes_to_delete(content->word))
+			while (has_quotes_to_delete(content->word, NULL))
 				content->word = delete_quotes(content->word);
 			if (dollar_flag == 1)
 				content->word = expand_exit_status(content->word,
@@ -139,7 +141,7 @@ static void	expander_redirects(t_list **redirects, t_data *data)
 				data->env_list);
 		else
 		{
-			while (has_quotes_to_delete(content->word))
+			while (has_quotes_to_delete(content->word, NULL))
 				content->word = delete_quotes(content->word);
 		}
 		current = current->next;

--- a/src/expander/expander.c
+++ b/src/expander/expander.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/04 14:14:28 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/04 15:28:40 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/04 17:35:19 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,7 +38,10 @@ void	expander_loop_dollar(t_simple_cmds *content, int i, int exit_status,
 		{
 			dollar_flag = checker_dollar(content->cmd[i], j);
 			while (has_quotes_to_delete(content->cmd[i]))
+			{
 				content->cmd[i] = delete_quotes(content->cmd[i]);
+				printf("word delete quotes: %s\n", content->cmd[i]);
+			}
 			if (dollar_flag == 5)
 				break ;
 			else if (dollar_flag == 3)
@@ -188,7 +191,7 @@ void	expander(t_data *data)
 				expander_loop_no_dollar(content, i);
 		}
 		expander_redirects(&content->redirects, data);
-		handle_empty_envs(old_cmd, content, &data->exit_status);
+		//handle_empty_envs(old_cmd, content, &data->exit_status);
 		current = current->next;
 		if (old_cmd != NULL)
 			free_array(old_cmd);

--- a/src/expander/expander.c
+++ b/src/expander/expander.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/04 14:14:28 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/04 17:35:19 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/05 01:33:36 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,10 +38,7 @@ void	expander_loop_dollar(t_simple_cmds *content, int i, int exit_status,
 		{
 			dollar_flag = checker_dollar(content->cmd[i], j);
 			while (has_quotes_to_delete(content->cmd[i]))
-			{
 				content->cmd[i] = delete_quotes(content->cmd[i]);
-				printf("word delete quotes: %s\n", content->cmd[i]);
-			}
 			if (dollar_flag == 5)
 				break ;
 			else if (dollar_flag == 3)
@@ -184,6 +181,8 @@ void	expander(t_data *data)
 		old_cmd = ft_strdup_array(content->cmd);
 		while (content->cmd[++i])
 		{
+			while (env_in_quotes_followed(content->cmd[i]))
+				expander_loop_dollar_no_space(data, content, i);
 			if (contains_dollar(content->cmd[i]))
 				expander_loop_dollar(content, i, data->exit_status,
 					data->env_list);
@@ -191,9 +190,7 @@ void	expander(t_data *data)
 				expander_loop_no_dollar(content, i);
 		}
 		expander_redirects(&content->redirects, data);
-		//handle_empty_envs(old_cmd, content, &data->exit_status);
+		handle_empty_envs(old_cmd, content, &data->exit_status);
 		current = current->next;
-		if (old_cmd != NULL)
-			free_array(old_cmd);
 	}
 }

--- a/src/expander/expander_checkers.c
+++ b/src/expander/expander_checkers.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/24 14:44:13 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/05 01:40:50 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/05 14:13:31 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,8 +52,13 @@ int	contains_dollar(char *str)
  */
 int	checker_dollar(char *str, int j)
 {
-	if (ft_strchr(str, '\'') != ft_strrchr(str, '\''))
+	if (str[0] == '\'' && str[ft_strlen_custom(str) - 1] == '\'')
 		return (5);
+	if (j > 0)
+	{
+		if (str[j - 1] == '\'' && str[ft_strlen_custom(str) - 1] == '\'')
+			return (5);
+	}
 	if (str[0] == '"' && str[ft_strlen_custom(str) - 1] == '"'
 		&& str[j + 1] == '\\')
 		return (4);
@@ -87,10 +92,10 @@ int	env_in_quotes_followed(char *str)
 	i = 0;
 	while (str[i])
 	{
-		if (str[i] == '\'')
-			return (0);
 		if (str[i] == '"' && str[i + 1] == '$')
 		{
+			if (i > 0 && str[i - 1] == '\'')
+				return (0);
 			j = 1;
 			while (str[i + j])
 			{

--- a/src/expander/expander_checkers.c
+++ b/src/expander/expander_checkers.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/24 14:44:13 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/05 14:13:31 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/06 12:57:54 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,7 +56,7 @@ int	checker_dollar(char *str, int j)
 		return (5);
 	if (j > 0)
 	{
-		if (str[j - 1] == '\'' && str[ft_strlen_custom(str) - 1] == '\'')
+		if (str[j - 1] == '\'' && str[0] != '"')
 			return (5);
 	}
 	if (str[0] == '"' && str[ft_strlen_custom(str) - 1] == '"'

--- a/src/expander/expander_checkers.c
+++ b/src/expander/expander_checkers.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/24 14:44:13 by aulicna           #+#    #+#             */
-/*   Updated: 2024/01/24 14:49:12 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/05 01:40:50 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,7 +52,7 @@ int	contains_dollar(char *str)
  */
 int	checker_dollar(char *str, int j)
 {
-	if ((str[0] == '\'' && str[ft_strlen_custom(str) - 1] == '\''))
+	if (ft_strchr(str, '\'') != ft_strrchr(str, '\''))
 		return (5);
 	if (str[0] == '"' && str[ft_strlen_custom(str) - 1] == '"'
 		&& str[j + 1] == '\\')
@@ -69,5 +69,37 @@ int	checker_dollar(char *str, int j)
 		return (2);
 	if (str[j + 1] == '?')
 		return (1);
+	return (0);
+}
+
+/**
+ * @brief	Checks for a case where an env is enclosed in double qoutes and
+ * not separate from the rest of the string with a space.
+ * 
+ * @param	str	string to check
+ * @return	int	1 is there is such a string, 0 otherwise
+*/
+int	env_in_quotes_followed(char *str)
+{
+	int	i;
+	int	j;
+
+	i = 0;
+	while (str[i])
+	{
+		if (str[i] == '\'')
+			return (0);
+		if (str[i] == '"' && str[i + 1] == '$')
+		{
+			j = 1;
+			while (str[i + j])
+			{
+				if (str[i + j] == '"' && str[i + j + 1] != '\0')
+					return (1);
+				j++;
+			}
+		}
+		i++;
+	}
 	return (0);
 }

--- a/src/expander/expander_construct.c
+++ b/src/expander/expander_construct.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/11 22:16:33 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/06 00:47:07 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/06 13:49:27 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,10 +39,10 @@
  * string in the 2D input array in the caller function.
  * 
  * Signal management:
- * g_signal set to SIGINT indicates that the previous user input was interrupted
- * by SIGINT (Ctrl+C) and hence the exit status to expand should be 130. Then
- * g_signal is reset, so that the current command (e.g. echo $?) makes it
- * to the execution (that doesn't happen unless g_signal is 0).
+ * g_signal set to SIGUSR1 indicates that the previous user input was
+ * interrupted by SIGINT (Ctrl+C) and hence the exit status to expand should be
+ * 130. Then g_signal is reset, so that the current command (e.g. echo $?)
+ * makes it to the execution (that doesn't happen unless g_signal is 0).
  * 
  * @param 	str			string to be expanded
  * @param	exit_status	exit status of the most recently executed foreground
@@ -59,7 +59,7 @@ char	*expand_exit_status(char *str, int exit_status)
 		i++;
 	init_struct_str(&new_str);
 	new_str.part_1 = ft_substr(str, 0, i);
-	if (g_signal == SIGINT)
+	if (g_signal == SIGUSR1)
 	{
 		exit_status = 130;
 		g_signal = 0;

--- a/src/expander/expander_construct.c
+++ b/src/expander/expander_construct.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/11 22:16:33 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/05 01:56:13 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/05 14:07:09 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -182,9 +182,12 @@ void	expander_loop_dollar_no_space(t_data *data, t_simple_cmds *content,
 	t_str	new_str;
 
 	j = 0;
-	while (content->cmd[i][j] != '"' && content->cmd[i][j + 1] != '$'
-		&& content->cmd[i][j])
+	while (content->cmd[i][j])
+	{
+		if (content->cmd[i][j] == '"' && content->cmd[i][j + 1] == '$')
+			break ;
 		j++;
+	}
 	init_struct_str(&new_str);
 	new_str.part_1 = ft_substr(content->cmd[i], 0, j);
 	j += 2;

--- a/src/expander/expander_construct.c
+++ b/src/expander/expander_construct.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/11 22:16:33 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/05 14:07:09 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/06 00:47:07 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,6 +38,12 @@
  * Finally, the new_string.final is returned and assigned to the appropriate
  * string in the 2D input array in the caller function.
  * 
+ * Signal management:
+ * g_signal set to SIGINT indicates that the previous user input was interrupted
+ * by SIGINT (Ctrl+C) and hence the exit status to expand should be 130. Then
+ * g_signal is reset, so that the current command (e.g. echo $?) makes it
+ * to the execution (that doesn't happen unless g_signal is 0).
+ * 
  * @param 	str			string to be expanded
  * @param	exit_status	exit status of the most recently executed foreground
  * 						pipeline
@@ -54,7 +60,10 @@ char	*expand_exit_status(char *str, int exit_status)
 	init_struct_str(&new_str);
 	new_str.part_1 = ft_substr(str, 0, i);
 	if (g_signal == SIGINT)
+	{
 		exit_status = 130;
+		g_signal = 0;
+	}
 	new_str.part_2 = ft_itoa(exit_status);
 	j = 2;
 	new_str.part_3 = ft_substr(str, i + j, ft_strlen_custom(str) - i - j);

--- a/src/expander/expander_empty_env.c
+++ b/src/expander/expander_empty_env.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/25 13:01:16 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/04 15:19:27 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/05 01:59:06 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -81,17 +81,36 @@ static char	**remove_cmd_empty_env(char **cmd, int i)
 	new_cmd = ft_calloc(len_2d, sizeof(char *));
 	j = 0;
 	new_j = 0;
-	while (cmd[j])
+	while (j < len_2d)
 	{
 		if (j == i)
 			j++;
-		new_cmd[new_j] = ft_strdup(cmd[j]);
+		if (cmd[j] != NULL)
+			new_cmd[new_j] = ft_strdup(cmd[j]);
 		j++;
 		new_j++;
 	}
 	new_cmd[new_j] = NULL;
 	free_array(cmd);
 	return (new_cmd);
+}
+
+/**
+ * @brief	Helper function for handle_empty_envs that safeguards only valid
+ * input (only if there are no redirections and old_cmd exists) to be processed.
+ * 
+ * @param	old_cmd		original simple_cmds array before expander
+ * @param	content		content of the current command (simple_cmds)
+*/
+static int	handle_empty_envs_omit(char **old_cmd, t_simple_cmds *content)
+{
+	if (content->redirects != NULL || old_cmd == NULL)
+	{
+		if (old_cmd != NULL)
+			free_array(old_cmd);
+		return (1);
+	}
+	return (0);
 }
 
 /**
@@ -112,7 +131,7 @@ void	handle_empty_envs(char **old_cmd, t_simple_cmds *content,
 	int	i;
 	int	old_i;
 
-	if (content->redirects != NULL && old_cmd == NULL)
+	if (handle_empty_envs_omit(old_cmd, content))
 		return ;
 	if (only_empty_envs(content->cmd))
 	{
@@ -132,4 +151,5 @@ void	handle_empty_envs(char **old_cmd, t_simple_cmds *content,
 		i++;
 		old_i++;
 	}
+	free_array(old_cmd);
 }

--- a/src/expander/quotes_delete.c
+++ b/src/expander/quotes_delete.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/28 12:35:35 by aulicna           #+#    #+#             */
-/*   Updated: 2024/01/24 15:37:07 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/05 14:37:44 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,14 +39,25 @@ int	get_quotes_type(char *str, char *q)
 /**
  * @brief	Checks whether there is a pair of quotes to delete from a string.
  * 
+ * For commands, it works with a copy of the original command before any
+ * expansion was performed to determine when to stop deleting quotes (e.g.
+ * one type of quotes enclosed in the other).
+ * 
  * It is done by comparing the pointer to their first and last occurence. If
  * those two equal, it means that there are no more quotes to delete as they
  * both evaluate to NULL.
  * 
  * @param	str	string to check
 */
-int	has_quotes_to_delete(char *str)
+int	has_quotes_to_delete(char *str, char *old_cmd)
 {
+	if (old_cmd)
+	{
+		if ((old_cmd[0] == '"' && old_cmd[ft_strlen_custom(old_cmd) - 1] == '"')
+			|| (old_cmd[0] == '\''
+				&& old_cmd[ft_strlen_custom(old_cmd) - 1] == '\''))
+			return (0);
+	}
 	if (ft_strchr(str, '"') != ft_strrchr(str, '"')
 		|| ft_strchr(str, '\'') != ft_strrchr(str, '\''))
 		return (1);
@@ -103,4 +114,25 @@ char	*delete_quotes(char *str)
 		return (new_str.final);
 	}
 	return (str);
+}
+
+/**
+ * @brief	Helper function for the expander_loop_dollar function
+ * that manages recursive quotes deletion from a word.
+ * 
+ * @param	content		pointer to t_simple_cmds struct
+ * @param	i			index of the command string in the array to process
+*/
+void	handle_quotes_deletion(t_simple_cmds *content, int i)
+{
+	char	*old_cmd;
+
+	old_cmd = ft_strdup(content->cmd[i]);
+	content->cmd[i] = delete_quotes(content->cmd[i]);
+	while (has_quotes_to_delete(content->cmd[i], old_cmd))
+	{
+		old_cmd = delete_quotes(old_cmd);
+		content->cmd[i] = delete_quotes(content->cmd[i]);
+	}
+	free(old_cmd);
 }

--- a/src/expander/quotes_delete.c
+++ b/src/expander/quotes_delete.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/28 12:35:35 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/05 14:37:44 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/06 13:46:21 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,9 +53,8 @@ int	has_quotes_to_delete(char *str, char *old_cmd)
 {
 	if (old_cmd)
 	{
-		if ((old_cmd[0] == '"' && old_cmd[ft_strlen_custom(old_cmd) - 1] == '"')
-			|| (old_cmd[0] == '\''
-				&& old_cmd[ft_strlen_custom(old_cmd) - 1] == '\''))
+		if (old_cmd[0] == '\''
+			&& old_cmd[ft_strlen_custom(old_cmd) - 1] == '\'')
 			return (0);
 	}
 	if (ft_strchr(str, '"') != ft_strrchr(str, '"')

--- a/src/heredoc/heredoc.c
+++ b/src/heredoc/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/14 10:23:00 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/06 00:43:37 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/06 13:20:43 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -74,8 +74,6 @@ static void	process_heredoc(t_data *data, t_list *current_redirect,
 		waitpid(pid, &status, 0);
 		if (WIFEXITED(status))
 			data->exit_status = WEXITSTATUS(status);
-		else if (WTERMSIG(status) == g_signal)
-			data->exit_status = 130;
 	}
 }
 

--- a/src/heredoc/heredoc.c
+++ b/src/heredoc/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/14 10:23:00 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/05 17:26:24 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/06 00:43:37 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,19 +40,12 @@ static char	*get_hd_file_name(void)
  * The function waits for the child to exit and saves the exit status into
  * the main t_data structure.
  * 
- * Signal lines (parent process):
- * 1. SIGINT: Ignores the SIGINT signal, so that the handle_sigint handler
- * doesn't get triggered in the parent process for now as there is a child
- * process running that has its own handler for this signal.
- * 
- * 2. SIGUSR1: Sets up the signal handler for SIGUSR1 to handle_sigint_heredoc
- * Thanks to that when the child process sends it to indicate that the heredoc
- * process has been interrupted by SIGINT (Ctrl + C), the parent process saves
- * this information in the global variable g_signal. This variable is then
- * checked in the minishell_loop before the execution is triggered and if
- * it is set to SIGUSR1, the execution won't be triggered because SIGINT
- * received during the heredoc process cancels the whole command.
- * 
+ * Signals management:
+ * In the child process, SIGINT handler prints a newline and exits with exit
+ * status of 130.
+ * In the parent process, SIGINT handler sets g_signal to SIGINT so that this
+ * value can be checked before launching exec (which shouldn't run if
+ * the heredoc process was interrupted with SIGINT).
  * 
  * @param	current_redirect		list containing heredoc content
  * @param	content_simle_cmd		pointer to the content of current_simple_cmd
@@ -77,7 +70,7 @@ static void	process_heredoc(t_data *data, t_list *current_redirect,
 	}
 	else
 	{
-		signal(SIGINT, handle_sigint_with_child);
+		signal(SIGINT, handle_sigint_when_child_running);
 		waitpid(pid, &status, 0);
 		if (WIFEXITED(status))
 			data->exit_status = WEXITSTATUS(status);

--- a/src/heredoc/heredoc.c
+++ b/src/heredoc/heredoc.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/14 10:23:00 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/02 14:26:45 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/05 17:26:24 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,17 +70,19 @@ static void	process_heredoc(t_data *data, t_list *current_redirect,
 	fork_process(&pid);
 	if (pid == 0)
 	{
+		signal(SIGINT, handle_sigint_heredoc);
 		create_heredoc(current_redirect, content_simple_cmd->hd_file,
 			data);
 		exit_minishell(NULL, 0);
 	}
 	else
 	{
-		signal(SIGINT, SIG_IGN);
-		signal(SIGUSR1, handle_sigint_heredoc);
+		signal(SIGINT, handle_sigint_with_child);
 		waitpid(pid, &status, 0);
 		if (WIFEXITED(status))
 			data->exit_status = WEXITSTATUS(status);
+		else if (WTERMSIG(status) == g_signal)
+			data->exit_status = 130;
 	}
 }
 

--- a/src/heredoc/heredoc_lines.c
+++ b/src/heredoc/heredoc_lines.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/14 17:48:09 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/01 16:50:36 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/05 00:28:12 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,6 +37,8 @@ static void	create_heredoc_dollar_line(int fd, char *line, t_data *data)
 	tmp_node->cmd[1] = NULL;
 	tmp_node->redirects = NULL;
 	tmp_node->hd_file = NULL;
+	if (env_in_quotes_followed(tmp_node->cmd[0]))
+		expander_loop_dollar_no_space(data, tmp_node, 0);
 	expander_loop_dollar(tmp_node, 0, data->exit_status, data->env_list);
 	ft_putstr_fd(tmp_node->cmd[0], fd);
 	free_array(tmp_node->cmd);

--- a/src/heredoc/heredoc_lines.c
+++ b/src/heredoc/heredoc_lines.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/14 17:48:09 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/05 00:28:12 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/05 16:54:56 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -96,8 +96,6 @@ void	create_heredoc(t_list *heredoc, char *hd_file_name, t_data *data)
 	char	*line;
 	char	*limiter;
 
-	signal(SIGINT, handle_sigint_heredoc);
-	signal(SIGUSR1, SIG_IGN);
 	data->hd_fd = open(hd_file_name, O_CREAT | O_RDWR | O_TRUNC, 0644);
 	line = readline("> ");
 	limiter = ((t_lexer *) heredoc->content)->word;

--- a/src/heredoc/heredoc_lines.c
+++ b/src/heredoc/heredoc_lines.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/14 17:48:09 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/05 16:54:56 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/05 23:11:36 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -76,15 +76,6 @@ static int	check_line_null(char *line, char *limiter)
  * to the file. If the line contains a dollar sign, expansion is performed
  * in the create_heredoc_dollar_line function before writing the line
  * in the file. Each line in the file is followed by a newline.
- * 
- * Signal lines:
- * 1. SIGINT: Sets up a signal handler for SIGINT that is different than the one
- * set in the parent process. When this signal is received,
- * handle_sigint_heredoc sends SIGUSR1 signal to all processes and then exits
- * minishell (it is the child process exiting, the parent keeps running).
- * 2. SIGUSR1: Ignores the SIGUSR1 signal, so that when handle_sigint_heredoc
- * sends it to all processes, it is processed (to indicate that the heredoc
- * process was interrupted by SIGINT) only in the parent process.
  * 
  * @param	heredoc			list containing heredoc content
  * @param	hd_file_name	name of the temporary heredoc file

--- a/src/utils/signals.c
+++ b/src/utils/signals.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/02 14:36:46 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/04 18:32:04 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/05 17:31:32 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@
  * received on the minishell prompt input (not in heredoc or hanging command).
  * 
  * When the SIGINT signal is received, the g_signal is set to SIGINT and checked
- * later on in the code, correctly assigning an exit_status of 130 is needed.
+ * later on in the code, correctly assigning an exit_status of 130 if needed.
  * 
  * Then the function writes a newline character to the standard output, prepares
  * readline library to accept a new line, replaces the current line
@@ -39,58 +39,45 @@ void	handle_sigint(int sig_num)
 	}
 }
 
+void	handle_sigint_with_child(int sig_num)
+{
+	if (sig_num == SIGINT)
+		g_signal = SIGINT;
+}
+
 /**
  * @brief	Handles the SIGINT and SIGUSR1 signals for a heredoc operation that
  * was interrupted by SIGINT.
  *
- * When the SIGUSR1 signal is received, a newline character is printed
- * to the standard output and the g_signal set to SIGUSR1.
- * 
- * When the SIGINT signal is received, the SIGUSR1 signal is sent to
- * all processes in the current process group and minishell exits.
- *
- * @param	sig_num	The signal number. This function handles SIGUSR1 and SIGINT.
+ * @param	sig_num	signal number
  */
 void	handle_sigint_heredoc(int sig_num)
 {
-	if (sig_num == SIGUSR1)
-	{
-		write(STDOUT, "\n", 1);
-		g_signal = SIGUSR1;
-	}
 	if (sig_num == SIGINT)
 	{
-		kill(0, SIGUSR1);
+		write(STDOUT, "\n", 1);
 		exit_minishell(NULL, 130);
 	}
 }
 
-/**
- * @brief	Handles the SIGINT and SIGUSR2 signals for a hanging command that 
- * was interrupted by SIGINT.
- *
- * When the SIGUSR2 signal is received, minishell exits with exit_status 130.
- * It is the child process that listens to this signal.
- * 
- * When the SIGINT signal is received, a new line character is printed 
- * to the standard input, g_signal is set to SIGUSR2 and SIGUSR2 signal is sent
- * to all processes in the current process group and then exits the minishell.
- * g_signal is checked for being equal to SIGUSR2 in the wait_for_pipeline
- * function as it indicates that there was a hanging command (in the child
- * process) and hence the whole command should exit with 130.
- *
- * @param	sig_num	The signal number. This function handles SIGUSR1 and SIGINT.
- */
-void	handle_sigint_hanging_command(int sig_num)
+void	reset_signals_default(void)
 {
-	if (sig_num == SIGUSR2)
-	{
-		exit_minishell(NULL, 130);
-	}
-	if (sig_num == SIGINT)
+	signal(SIGQUIT, SIG_DFL);
+	signal(SIGINT, SIG_DFL);
+}
+
+int	signal_exit_of_child(int *status)
+{
+	if (WTERMSIG(*status) == g_signal)
 	{
 		write(STDOUT, "\n", 1);
-		g_signal = SIGUSR2;
-		kill(0, SIGUSR2);
+		g_signal = 0;
+		return (130);
 	}
+	if (WTERMSIG(*status) == SIGQUIT)
+	{
+		write(1, "Quit\n", 5);
+		return (131);
+	}
+	return (0);
 }

--- a/src/utils/signals.c
+++ b/src/utils/signals.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/02 14:36:46 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/05 23:18:04 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/06 13:48:57 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,8 +18,8 @@
  * This function handles the SIGINT signal (pressing Ctrl+C) when minishell is
  * in interactive mode, meaning that it is waiting for user input.
  * 
- * When the SIGINT signal is received, the g_signal is set to SIGINT and checked
- * later on in the code to correctly assign an exit status of 130.
+ * When the SIGINT signal is received, the g_signal is set to SIGUSR1 and
+ * checked later on in the code to correctly assign an exit status of 130.
  * 
  * Then the function writes a newline character to the standard output, prepares
  * readline library to accept a new line, replaces the current line
@@ -31,7 +31,7 @@ void	handle_sigint(int sig_num)
 {
 	if (sig_num == SIGINT)
 	{
-		g_signal = SIGINT;
+		g_signal = SIGUSR1;
 		write(STDOUT, "\n", 1);
 		rl_on_new_line();
 		rl_replace_line("", 0);
@@ -126,7 +126,7 @@ int	signal_exit_of_child(int *status)
 	}
 	if (WTERMSIG(*status) == SIGQUIT)
 	{
-		write(1, "Quit\n", 5);
+		write(1, "Quit (core dumped)\n", 19);
 		return (131);
 	}
 	return (0);

--- a/src/utils/signals.c
+++ b/src/utils/signals.c
@@ -6,7 +6,7 @@
 /*   By: aulicna <aulicna@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/02 14:36:46 by aulicna           #+#    #+#             */
-/*   Updated: 2024/02/02 14:36:51 by aulicna          ###   ########.fr       */
+/*   Updated: 2024/02/04 18:32:04 by aulicna          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,8 +55,8 @@ void	handle_sigint_heredoc(int sig_num)
 {
 	if (sig_num == SIGUSR1)
 	{
-		g_signal = SIGUSR1;
 		write(STDOUT, "\n", 1);
+		g_signal = SIGUSR1;
 	}
 	if (sig_num == SIGINT)
 	{


### PR DESCRIPTION
- #149 and #150 
  - expander fixes to handle more quote combinations

-  #135 
   - signals managed in a different way - everything is documented in the code, recommended reading flow:
    - ```signal.c``` to get an overview
    - and then ```main.c (minishell_loop)``` -> ```heredoc.c`(process_heredoc)``` -> ```exec.c (exec_pipeline and fork_cmd)``` -> ```pipe_utils.c (wait_for_pipeline)``` 

- **Other**
  - added documentation for ```free_pipe.c``` 